### PR TITLE
feat: use --mkpath on rsync only if available

### DIFF
--- a/upload-files/action.yml
+++ b/upload-files/action.yml
@@ -41,11 +41,18 @@ runs:
           UPLOAD_FULL_PATH+="run-${{ github.run_id }}/"
         fi
 
+        mkpath_flag=""
+
+        if rsync --help | grep mkpath >/dev/null; then
+          mkpath_flag="--mkpath"
+        else
+          ssh ${{ env.server-username }}@${{ env.server-address }} "mkdir -p ${UPLOAD_FULL_PATH}"
+        fi
+
         echo "::group::Uploading files..."
         rsync \
           -avzhH \
-          --ignore-missing-args \
-          --mkpath \
+          --ignore-missing-args $mkpath_flag \
           ${UPLOAD_FROM%/}/${{ inputs.upload-pattern }} \
           ${{ env.server-username }}@${{ env.server-address }}:${UPLOAD_FULL_PATH}
         echo "::endgroup::"


### PR DESCRIPTION
`--mkpath` flag is not available in older version of `rsync`, specifically version `3.1.3` which is the one available in Ubuntu Focal. This PR looks for that flag and if the version of `rsync` doesn't have it, it will fallback on creating the directory using `mkdir -p` over `ssh`.