### PR TITLE
feat: skip updating testing model if distro doesn't exist

### DIFF
--- a/prepare-release/entrypoint.sh
+++ b/prepare-release/entrypoint.sh
@@ -147,8 +147,10 @@ update_model() {
 
   echo "Updating package in 'testing/${model_sub_path}'."
 
-  mkdir -p "${model_path}"
-  touch "${model_path%/}/package-model.json"
+  if [ ! -d "$model_path" ] || [ ! -f "$model_file" ]; then
+    echo "Warning: Model file 'testing/${model_sub_path}' not found."
+    return 1
+  fi
 
   jq -S '.packages.["'"${PACKAGE_NAME}"'"].ref="'"$RELEASE_VERSION"'" | .packages.["'"${PACKAGE_NAME}"'"].source="'"$PACKAGE_REPO"'" ' "$model_file" > "$model_file.tmp"
 


### PR DESCRIPTION
This is particularly useful where distro can be defined in `unstable` stage, for early testing/development purposes without introducing the distro in, the more stable, `testing` stage.

When time comes, the stage model for the distro should be manually added in `testing` folder and the process will pick that up from then on.