### PR TITLE
feat: add packaging/v1.10-regolith to supported release ref

### DIFF
--- a/prepare-release/entrypoint.sh
+++ b/prepare-release/entrypoint.sh
@@ -55,6 +55,7 @@ generate_tag_name() {
     "sway-regolith:::packaging/v1.7-regolith")    full_version+="-ubuntu-jammy" ;;
     "sway-regolith:::packaging/v1.8-regolith")    full_version+="-debian-testing" ;;
     "sway-regolith:::packaging/v1.9-regolith")    ;;
+    "sway-regolith:::packaging/v1.10-regolith")   ;;
     "whitesur-gtk-theme:::debian")                ;;
 
     # This package is exceptional. It is not built from a regolith repo and cannot push tags.


### PR DESCRIPTION
Add `packaging/v1.10-regolith` on `sway-regolith` to the list of supported refs to prepare a release from.